### PR TITLE
fix: update golangci-lint configuration for v1.64.8 compatibility

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,9 +19,6 @@ linters-settings:
 
   govet:
     enable-all: true
-    
-  shadow:
-    strict: true
 
   gocyclo:
     min-complexity: 15
@@ -75,10 +72,10 @@ linters-settings:
       - return
       - assign
     ignored-numbers:
-      - 0
-      - 1
-      - 2
-      - 3
+      - "0"
+      - "1"
+      - "2"
+      - "3"
     ignored-functions:
       - strings.SplitN
 
@@ -89,11 +86,11 @@ linters-settings:
       - HACK
 
   depguard:
-    list-type: blacklist
-    packages:
-      - github.com/sirupsen/logrus
-    packages-with-error-message:
-      - github.com/sirupsen/logrus: "logging is allowed only by logutils.Log"
+    rules:
+      main:
+        deny:
+          - pkg: github.com/sirupsen/logrus
+            desc: "logging is allowed only by logutils.Log"
 
 linters:
   disable-all: true


### PR DESCRIPTION
Fixes golangci-lint configuration validation errors with version 1.64.8

## Changes
- Convert mnd.ignored-numbers from integers to strings
- Update depguard configuration to use new rules.main.deny format
- Remove deprecated shadow configuration from linters-settings

Fixes #3

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting configuration to align with current coding standards.
  * Simplified shadow linter settings for clearer defaults.
  * Adjusted magic-number ignores to improve readability and consistency.
  * Migrated dependency guard to a rules-based policy to enforce consistent library usage (e.g., unified logging).
  
* **Developer Experience**
  * Streamlined static analysis rules for more predictable linting feedback.
  * Reduced configuration complexity to make contributions smoother and reviews more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->